### PR TITLE
fix(parameters): use `replace` for compatibility

### DIFF
--- a/src/utils/handleParameters.ts
+++ b/src/utils/handleParameters.ts
@@ -1,26 +1,28 @@
-/* eslint-disable @typescript-eslint/typedef */
 export const handleParameters = (token: string): string => {
-  const squareBracketRegex: RegExp = /\[(.*)\]/gu;
-  const tsRegex: RegExp = /\.ts$/u;
-  const jsRegex: RegExp = /\.js$/u;
-  const wildCardRouteRegex: RegExp = /\[\.\.\..+\]/gu;
+  const squareBracketRegex = /\[(.*)\]/gu;
+  const tsRegex = /\.ts$/u;
+  const jsRegex = /\.js$/u;
+  const wildCardRouteRegex = /\[\.\.\..+\]/gu;
+  const multipleParamRegex = /\]-\[/gu;
+  const routeParamRegex = /\]\/\[/gu;
 
   // This will clean the url extensions like .ts or .js
   const tokenToBeReplaced: string = token
     .replace(tsRegex, "")
     .replace(jsRegex, "");
   // This will handle wild card based routes - users/[...id]/profile.ts -> users/*/profile
-  const wildCardRouteHandled: string = tokenToBeReplaced.replaceAll(
+  const wildCardRouteHandled: string = tokenToBeReplaced.replace(
     wildCardRouteRegex,
     () => "*"
   );
 
   // This will handle the generic square bracket based routes - users/[id]/index.ts -> users/:id
-  const url = wildCardRouteHandled.replaceAll(
+  const url = wildCardRouteHandled.replace(
     squareBracketRegex,
     (subString, match) => `:${String(match)}`
   );
+
   // This will handle the case when multiple parameters are present in one file like -
   //users / [id] - [name].ts to users /: id -:name and users / [id] - [name] / [age].ts to users /: id -: name /: age
-  return url.replaceAll("]-[", "-:").replaceAll("]/[", "/:");
+  return url.replace(multipleParamRegex, "-:").replace(routeParamRegex, "/:");
 };


### PR DESCRIPTION
 [String.prototype.replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) is only available in Node 15 or after. If you try and use it in a version below 15 it will crash and not be able to mount any routes.

Instead of using `replaceAll()` using [String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) and providing its `searchValue` with global flag so that it can match against the whole string.

This should help offer greater compatibility among node versions. 

