### PR TITLE
Make the Route and AnyRoute types generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 ## [1.1.2](https://github.com/spa5k/fastify-file-routes/compare/v1.1.1...v1.1.2) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **parameters:** 🐛 use replace for comptability ([94df65b](https://github.com/spa5k/fastify-file-routes/commit/94df65b47fd4e12eedced71940f22fc5de3838d9))
+- **parameters:** 🐛 use replace for comptability ([94df65b](https://github.com/spa5k/fastify-file-routes/commit/94df65b47fd4e12eedced71940f22fc5de3838d9))
 
 ## [1.1.1](https://github.com/spa5k/fastify-file-routes/compare/v1.1.0...v1.1.1) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **typescript:** 🔥 removing type json schema until a  better way to infer type is thought off ([c274cc0](https://github.com/spa5k/fastify-file-routes/commit/c274cc0f444af0f3b7912013a4d9446429f363a6))
+- **typescript:** 🔥 removing type json schema until a better way to infer type is thought off ([c274cc0](https://github.com/spa5k/fastify-file-routes/commit/c274cc0f444af0f3b7912013a4d9446429f363a6))
 
 # [1.1.0](https://github.com/spa5k/fastify-file-routes/compare/v1.0.3...v1.1.0) (2021-12-21)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@commitlint/cli': 16.2.1
@@ -57,11 +57,11 @@ devDependencies:
   '@semantic-release/github': 8.0.2_semantic-release@19.0.2
   '@semantic-release/npm': 9.0.1_semantic-release@19.0.2
   '@semantic-release/release-notes-generator': 10.0.3_semantic-release@19.0.2
-  '@spa5k/eslint-config': 0.0.2_eslint@8.10.0+typescript@4.6.2
+  '@spa5k/eslint-config': 0.0.2_pzezdwkd5bvjkx2hshexc25sxq
   '@types/jest': 27.4.1
   '@types/node': 17.0.21
-  '@typescript-eslint/eslint-plugin': 5.14.0_f4054b8c3cd621db16ae1b9d571bccc0
-  '@typescript-eslint/parser': 5.14.0_eslint@8.10.0+typescript@4.6.2
+  '@typescript-eslint/eslint-plugin': 5.14.0_6qcuxdb42yq5wfvodoovog6mya
+  '@typescript-eslint/parser': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
   c8: 7.11.0
   commitizen: 4.2.4
   dotenv: 16.0.0
@@ -69,7 +69,7 @@ devDependencies:
   eslint: 8.10.0
   eslint-config-galex: 3.6.5_eslint@8.10.0
   eslint-import-resolver-node: 0.3.6
-  eslint-plugin-import: 2.25.4_eslint@8.10.0
+  eslint-plugin-import: 2.25.4_bpewy4jhf2e3jtlhlmcpnspzbi
   eslint-plugin-inclusive-language: 2.2.0
   eslint-plugin-jest-formatting: 3.1.0_eslint@8.10.0
   eslint-plugin-promise: 6.0.0_eslint@8.10.0
@@ -83,9 +83,9 @@ devDependencies:
   prettier: 2.5.1
   semantic-release: 19.0.2
   start-server-and-test: 1.14.0
-  ts-node: 10.7.0_e79e62fe450383fd2d418267dc75e645
+  ts-node: 10.7.0_46pgf7sfaob72lkbqjt5y5pgiu
   tslib: 2.3.1
-  tsup: 5.12.0_ts-node@10.7.0+typescript@4.6.2
+  tsup: 5.12.0_ydznwdtnuvt5v5poxvazn5c734
   typescript: 4.6.2
   vite: 2.8.6
   vitest: 0.6.0_c8@7.11.0
@@ -134,7 +134,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.17.0_@babel+core@7.17.4+eslint@8.10.0:
+  /@babel/eslint-parser/7.17.0_etdanmcnfjytfloatv7wjui54e:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -288,6 +288,8 @@ packages:
     resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/plugin-syntax-jsx/7.16.7_@babel+core@7.17.4:
@@ -498,7 +500,7 @@ packages:
       '@types/node': 17.0.21
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 1.0.5_e79e62fe450383fd2d418267dc75e645
+      cosmiconfig-typescript-loader: 1.0.5_46pgf7sfaob72lkbqjt5y5pgiu
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.6.2
@@ -805,39 +807,39 @@ packages:
     resolution: {integrity: sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets/0.3.4_eslint@8.10.0+typescript@4.6.2:
+  /@rushstack/eslint-plugin-packlets/0.3.4_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-OSA58EZCx4Dw15UDdvNYGGHziQmhiozKQiOqDjn8ZkrCM3oyJmI6dduSJi57BGlb/C4SpY7+/88MImId7Y5cxA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.2
-      '@typescript-eslint/experimental-utils': 5.3.1_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/experimental-utils': 5.3.1_pzezdwkd5bvjkx2hshexc25sxq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.2.4_eslint@8.10.0+typescript@4.6.2:
+  /@rushstack/eslint-plugin-security/0.2.4_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-MWvM7H4vTNHXIY/SFcFSVgObj5UD0GftBM8UcIE1vXrPwdVYXDgDYXrSXdx7scWS4LYKPLBVoB3v6/Trhm2wug==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.2
-      '@typescript-eslint/experimental-utils': 5.3.1_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/experimental-utils': 5.3.1_pzezdwkd5bvjkx2hshexc25sxq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin/0.8.4_eslint@8.10.0+typescript@4.6.2:
+  /@rushstack/eslint-plugin/0.8.4_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-c8cY9hvak+1EQUGlJxPihElFB/5FeQCGyULTGRLe5u6hSKKtXswRqc23DTo87ZMsGd4TaScPBRNKSGjU5dORkg==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.2
-      '@typescript-eslint/experimental-utils': 5.3.1_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/experimental-utils': 5.3.1_pzezdwkd5bvjkx2hshexc25sxq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
@@ -992,16 +994,16 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@spa5k/eslint-config/0.0.2_eslint@8.10.0+typescript@4.6.2:
+  /@spa5k/eslint-config/0.0.2_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-Dd+Ld+8T26hqIwILUL9+2hjSVyCXL/lSO4VLyDPpkrQXWaEkdo0AwbKQnHBX0ll0dpUfo2TI2z58fXIhC1JgiA==}
     dependencies:
       '@rushstack/eslint-patch': 1.1.0
-      '@rushstack/eslint-plugin': 0.8.4_eslint@8.10.0+typescript@4.6.2
-      '@rushstack/eslint-plugin-packlets': 0.3.4_eslint@8.10.0+typescript@4.6.2
-      '@rushstack/eslint-plugin-security': 0.2.4_eslint@8.10.0+typescript@4.6.2
-      '@typescript-eslint/eslint-plugin': 5.10.2_34d0b62715f15dabbdf2d6d3e9c520c0
-      '@typescript-eslint/experimental-utils': 5.10.2_eslint@8.10.0+typescript@4.6.2
-      '@typescript-eslint/parser': 5.10.2_eslint@8.10.0+typescript@4.6.2
+      '@rushstack/eslint-plugin': 0.8.4_pzezdwkd5bvjkx2hshexc25sxq
+      '@rushstack/eslint-plugin-packlets': 0.3.4_pzezdwkd5bvjkx2hshexc25sxq
+      '@rushstack/eslint-plugin-security': 0.2.4_pzezdwkd5bvjkx2hshexc25sxq
+      '@typescript-eslint/eslint-plugin': 5.10.2_gtilmjyv6fo2xpps23j6trjaya
+      '@typescript-eslint/experimental-utils': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
+      '@typescript-eslint/parser': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
       '@typescript-eslint/typescript-estree': 5.10.2_typescript@4.6.2
       eslint-plugin-promise: 6.0.0_eslint@8.10.0
       eslint-plugin-react: 7.28.0_eslint@8.10.0
@@ -1109,7 +1111,7 @@ packages:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.10.2_34d0b62715f15dabbdf2d6d3e9c520c0:
+  /@typescript-eslint/eslint-plugin/5.10.2_gtilmjyv6fo2xpps23j6trjaya:
     resolution: {integrity: sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1120,10 +1122,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.10.2_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/parser': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
       '@typescript-eslint/scope-manager': 5.10.2
-      '@typescript-eslint/type-utils': 5.10.2_eslint@8.10.0+typescript@4.6.2
-      '@typescript-eslint/utils': 5.10.2_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/type-utils': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
+      '@typescript-eslint/utils': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       functional-red-black-tree: 1.0.1
@@ -1136,7 +1138,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.12.0_7171b812dd4c0026711965a6ab6481fa:
+  /@typescript-eslint/eslint-plugin/5.12.0_ofy3qew5jqacm4izmwtkwzeb7i:
     resolution: {integrity: sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1147,10 +1149,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/parser': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
       '@typescript-eslint/scope-manager': 5.12.0
-      '@typescript-eslint/type-utils': 5.12.0_eslint@8.10.0+typescript@4.5.5
-      '@typescript-eslint/utils': 5.12.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/type-utils': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
+      '@typescript-eslint/utils': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
       debug: 4.3.3
       eslint: 8.10.0
       functional-red-black-tree: 1.0.1
@@ -1163,7 +1165,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.14.0_f4054b8c3cd621db16ae1b9d571bccc0:
+  /@typescript-eslint/eslint-plugin/5.14.0_6qcuxdb42yq5wfvodoovog6mya:
     resolution: {integrity: sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1174,10 +1176,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.14.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/parser': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
       '@typescript-eslint/scope-manager': 5.14.0
-      '@typescript-eslint/type-utils': 5.14.0_eslint@8.10.0+typescript@4.6.2
-      '@typescript-eslint/utils': 5.14.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/type-utils': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
+      '@typescript-eslint/utils': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       functional-red-black-tree: 1.0.1
@@ -1190,33 +1192,33 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.10.2_eslint@8.10.0+typescript@4.5.5:
+  /@typescript-eslint/experimental-utils/5.10.2_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-stRnIlxDduzxtaVLtEohESoXI1k7J6jvJHGyIkOT2pvXbg5whPM6f9tzJ51bJJxaJTdmvwgVFDNCopFRb2F5Gw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.10.2_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.10.2_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/experimental-utils/5.10.2_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-stRnIlxDduzxtaVLtEohESoXI1k7J6jvJHGyIkOT2pvXbg5whPM6f9tzJ51bJJxaJTdmvwgVFDNCopFRb2F5Gw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.10.2_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/utils': 5.10.2_zlvujy5mo3bfvwuw46uoxyougq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.3.1_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/experimental-utils/5.3.1_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1234,7 +1236,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.10.2_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/parser/5.10.2_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1254,7 +1256,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.12.0_eslint@8.10.0+typescript@4.5.5:
+  /@typescript-eslint/parser/5.12.0_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1274,7 +1276,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.14.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/parser/5.14.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1326,7 +1328,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.3.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.10.2_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/type-utils/5.10.2_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1336,7 +1338,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.10.2_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/utils': 5.10.2_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       tsutils: 3.21.0_typescript@4.6.2
@@ -1345,7 +1347,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.12.0_eslint@8.10.0+typescript@4.5.5:
+  /@typescript-eslint/type-utils/5.12.0_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1355,7 +1357,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.12.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
       debug: 4.3.3
       eslint: 8.10.0
       tsutils: 3.21.0_typescript@4.5.5
@@ -1364,7 +1366,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.14.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/type-utils/5.14.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1374,7 +1376,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.14.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/utils': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       tsutils: 3.21.0_typescript@4.6.2
@@ -1529,25 +1531,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.10.2_eslint@8.10.0+typescript@4.5.5:
-    resolution: {integrity: sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.10.2
-      '@typescript-eslint/types': 5.10.2
-      '@typescript-eslint/typescript-estree': 5.10.2_typescript@4.5.5
-      eslint: 8.10.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.10.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.10.2_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/utils/5.10.2_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1565,7 +1549,25 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.12.0_eslint@8.10.0+typescript@4.5.5:
+  /@typescript-eslint/utils/5.10.2_zlvujy5mo3bfvwuw46uoxyougq:
+    resolution: {integrity: sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.10.2
+      '@typescript-eslint/types': 5.10.2
+      '@typescript-eslint/typescript-estree': 5.10.2_typescript@4.5.5
+      eslint: 8.10.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.10.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.12.0_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1583,25 +1585,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.14.0_eslint@8.10.0+typescript@4.5.5:
-    resolution: {integrity: sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.14.0
-      '@typescript-eslint/types': 5.14.0
-      '@typescript-eslint/typescript-estree': 5.14.0_typescript@4.5.5
-      eslint: 8.10.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.10.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.14.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/utils/5.14.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1611,6 +1595,24 @@ packages:
       '@typescript-eslint/scope-manager': 5.14.0
       '@typescript-eslint/types': 5.14.0
       '@typescript-eslint/typescript-estree': 5.14.0_typescript@4.6.2
+      eslint: 8.10.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.10.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.14.0_zlvujy5mo3bfvwuw46uoxyougq:
+    resolution: {integrity: sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.14.0
+      '@typescript-eslint/types': 5.14.0
+      '@typescript-eslint/typescript-estree': 5.14.0_typescript@4.5.5
       eslint: 8.10.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.10.0
@@ -2255,8 +2257,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2268,8 +2270,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2296,7 +2298,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/1.0.5_e79e62fe450383fd2d418267dc75e645:
+  /cosmiconfig-typescript-loader/1.0.5_46pgf7sfaob72lkbqjt5y5pgiu:
     resolution: {integrity: sha512-FL/YR1nb8hyN0bAcP3MBaIoZravfZtVsN/RuPnoo6UVjqIrDxSNIpXHCGgJe0ZWy5yImpyD6jq5wCJ5f1nUv8g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -2305,7 +2307,7 @@ packages:
     dependencies:
       '@types/node': 17.0.21
       cosmiconfig: 7.0.1
-      ts-node: 10.7.0_e79e62fe450383fd2d418267dc75e645
+      ts-node: 10.7.0_46pgf7sfaob72lkbqjt5y5pgiu
       typescript: 4.6.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -2393,12 +2395,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -2855,17 +2867,17 @@ packages:
       eslint: '>=8.7.0'
     dependencies:
       '@babel/core': 7.17.4
-      '@babel/eslint-parser': 7.17.0_@babel+core@7.17.4+eslint@8.10.0
+      '@babel/eslint-parser': 7.17.0_etdanmcnfjytfloatv7wjui54e
       '@babel/preset-react': 7.16.7_@babel+core@7.17.4
       '@next/eslint-plugin-next': 12.0.10
-      '@typescript-eslint/eslint-plugin': 5.12.0_7171b812dd4c0026711965a6ab6481fa
-      '@typescript-eslint/parser': 5.12.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/eslint-plugin': 5.12.0_ofy3qew5jqacm4izmwtkwzeb7i
+      '@typescript-eslint/parser': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
       confusing-browser-globals: 1.0.11
       eslint: 8.10.0
       eslint-config-prettier: 8.3.0_eslint@8.10.0
       eslint-import-resolver-jsconfig: 1.1.0
-      eslint-plugin-import: 2.25.4_eslint@8.10.0
-      eslint-plugin-jest: 26.1.1_2ee1ffd6eed841d3dd9a5ae5cf28f18d
+      eslint-plugin-import: 2.25.4_cauuzuviao26kba434cpghffvq
+      eslint-plugin-jest: 26.1.1_f3q77vxo3ba5hxm2lls46khrru
       eslint-plugin-jest-dom: 4.0.1_eslint@8.10.0
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.10.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.10.0
@@ -2873,12 +2885,14 @@ packages:
       eslint-plugin-react: 7.28.0_eslint@8.10.0
       eslint-plugin-react-hooks: 4.3.0_eslint@8.10.0
       eslint-plugin-sonarjs: 0.11.0_eslint@8.10.0
-      eslint-plugin-storybook: 0.5.6_eslint@8.10.0+typescript@4.5.5
-      eslint-plugin-testing-library: 5.0.5_eslint@8.10.0+typescript@4.5.5
+      eslint-plugin-storybook: 0.5.6_zlvujy5mo3bfvwuw46uoxyougq
+      eslint-plugin-testing-library: 5.0.5_zlvujy5mo3bfvwuw46uoxyougq
       eslint-plugin-unicorn: 40.1.0_eslint@8.10.0
       read-pkg-up: 7.0.1
       typescript: 4.5.5
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - jest
       - supports-color
     dev: true
@@ -2905,29 +2919,80 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_f7cvbvsk23iagm5b6lnvedcsuy:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.25.4_eslint@8.10.0:
+  /eslint-module-utils/2.7.3_u6wdthctpfvz27dbafug4zwjd4:
+    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
+      debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
+      find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import/2.25.4_bpewy4jhf2e3jtlhlmcpnspzbi:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.14.0_pzezdwkd5bvjkx2hshexc25sxq
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.10.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_f7cvbvsk23iagm5b6lnvedcsuy
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -2935,6 +3000,41 @@ packages:
       object.values: 1.1.5
       resolve: 1.20.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import/2.25.4_cauuzuviao26kba434cpghffvq:
+    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.12.0_zlvujy5mo3bfvwuw46uoxyougq
+      array-includes: 3.1.4
+      array.prototype.flat: 1.2.5
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 8.10.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-module-utils: 2.7.3_u6wdthctpfvz27dbafug4zwjd4
+      has: 1.0.3
+      is-core-module: 2.8.0
+      is-glob: 4.0.3
+      minimatch: 3.0.4
+      object.values: 1.1.5
+      resolve: 1.20.0
+      tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-inclusive-language/2.2.0:
@@ -2964,7 +3064,7 @@ packages:
       eslint: 8.10.0
     dev: true
 
-  /eslint-plugin-jest/26.1.1_2ee1ffd6eed841d3dd9a5ae5cf28f18d:
+  /eslint-plugin-jest/26.1.1_f3q77vxo3ba5hxm2lls46khrru:
     resolution: {integrity: sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -2977,8 +3077,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.0_7171b812dd4c0026711965a6ab6481fa
-      '@typescript-eslint/utils': 5.14.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/eslint-plugin': 5.12.0_ofy3qew5jqacm4izmwtkwzeb7i
+      '@typescript-eslint/utils': 5.14.0_zlvujy5mo3bfvwuw46uoxyougq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
@@ -3070,14 +3170,14 @@ packages:
       eslint: 8.10.0
     dev: true
 
-  /eslint-plugin-storybook/0.5.6_eslint@8.10.0+typescript@4.5.5:
+  /eslint-plugin-storybook/0.5.6_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-hxeydYXi0DZC80kV9wPz9pA9oG9GVdfNg9iXR/KhqnMdqZWCGQKsex05k4VlX52no7mm/sICjW/iKYtRqVkaaw==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/experimental-utils': 5.10.2_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/experimental-utils': 5.10.2_zlvujy5mo3bfvwuw46uoxyougq
       eslint: 8.10.0
       requireindex: 1.2.0
     transitivePeerDependencies:
@@ -3085,13 +3185,13 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-testing-library/5.0.5_eslint@8.10.0+typescript@4.5.5:
+  /eslint-plugin-testing-library/5.0.5_zlvujy5mo3bfvwuw46uoxyougq:
     resolution: {integrity: sha512-0j355vJpJCE/2g+aayIgJRUB6jBVqpD5ztMLGcadR1PgrgGPnPxN1HJuOAsAAwiMo27GwRnpJB8KOQzyNuNZrw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.14.0_eslint@8.10.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.14.0_zlvujy5mo3bfvwuw46uoxyougq
       eslint: 8.10.0
     transitivePeerDependencies:
       - supports-color
@@ -5251,7 +5351,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.4
-      ts-node: 10.7.0_e79e62fe450383fd2d418267dc75e645
+      ts-node: 10.7.0_46pgf7sfaob72lkbqjt5y5pgiu
       yaml: 1.10.2
     dev: true
 
@@ -6147,7 +6247,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node/10.7.0_e79e62fe450383fd2d418267dc75e645:
+  /ts-node/10.7.0_46pgf7sfaob72lkbqjt5y5pgiu:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -6199,7 +6299,7 @@ packages:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
     dev: true
 
-  /tsup/5.12.0_ts-node@10.7.0+typescript@4.6.2:
+  /tsup/5.12.0_ydznwdtnuvt5v5poxvazn5c734:
     resolution: {integrity: sha512-FGZZNikQYGlEPtKEnz04hEniEO9ctP0rfWOdDeJCpFY4sqQe+TE90YNsv/1g0FshXoGYAOTFDYAVHg6Ovh003Q==}
     hasBin: true
     peerDependencies:

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -3,15 +3,15 @@ import type { RouteOptions } from "fastify";
 export const errorLabel = "[ERROR] fastify-file-routes:" as const;
 
 export type ValidMethods =
-  | "DELETE"
-  | "GET"
-  | "HEAD"
-  | "PATCH"
-  | "POST"
-  | "PUT"
-  | "OPTIONS";
+  | "delete"
+  | "get"
+  | "head"
+  | "patch"
+  | "post"
+  | "put"
+  | "options";
 
-export const validMethods: Set<string> = new Set([
+export const validMethods = new Set([
   "delete",
   "get",
   "head",
@@ -54,13 +54,7 @@ export type Route<
   Querystring extends RouteInterfaceRecord = unknown,
   Reply = unknown
 > = {
-  delete?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
-  get?: Omit<AnyRoute<Body, Headers, Params, Querystring, Reply>, "body">;
-  head?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
-  patch?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
-  post?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
-  put?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
-  options?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  [Key in ValidMethods]?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
 };
 
 export type FileRoutesOptions = {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,7 +1,6 @@
 import type { RouteOptions } from "fastify";
 
-export const errorLabel: "[ERROR] fastify-file-routes:" =
-  "[ERROR] fastify-file-routes:";
+export const errorLabel = "[ERROR] fastify-file-routes:" as const;
 
 export type ValidMethods =
   | "DELETE"
@@ -22,28 +21,46 @@ export const validMethods: Set<string> = new Set([
   "options",
 ]);
 
-export type AnyRoute = Omit<RouteOptions, "method" | "url">;
+export type RouteInterfaceRecord = Record<string, unknown> | unknown;
 
-export type DeleteRoute = AnyRoute;
-export type GetRoute = Omit<AnyRoute, "body">;
-export type HeadRoute = AnyRoute;
-export type PatchRoute = AnyRoute;
-export type PostRoute = AnyRoute;
-export type PutRoute = AnyRoute;
-export type OptionsRoute = AnyRoute;
+export type AnyRoute<
+  Body = unknown,
+  Headers extends RouteInterfaceRecord = unknown,
+  Params extends RouteInterfaceRecord = unknown,
+  Querystring extends RouteInterfaceRecord = unknown,
+  Reply = unknown
+> = Omit<
+  // Uses never to use the defaults from fastify
+  RouteOptions<
+    never,
+    never,
+    never,
+    {
+      Body: Body;
+      Headers: Headers;
+      Params: Params;
+      Querystring: Querystring;
+      Reply: Reply;
+    },
+    never
+  >,
+  "method" | "url"
+>;
 
-export type Security = {
-  [key: string]: string[];
-};
-
-export type Route = {
-  delete?: DeleteRoute;
-  get?: GetRoute;
-  head?: HeadRoute;
-  patch?: PatchRoute;
-  post?: PostRoute;
-  put?: PutRoute;
-  options?: OptionsRoute;
+export type Route<
+  Body = unknown,
+  Headers extends RouteInterfaceRecord = unknown,
+  Params extends RouteInterfaceRecord = unknown,
+  Querystring extends RouteInterfaceRecord = unknown,
+  Reply = unknown
+> = {
+  delete?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  get?: Omit<AnyRoute<Body, Headers, Params, Querystring, Reply>, "body">;
+  head?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  patch?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  post?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  put?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
+  options?: AnyRoute<Body, Headers, Params, Querystring, Reply>;
 };
 
 export type FileRoutesOptions = {

--- a/src/utils/autoload.ts
+++ b/src/utils/autoload.ts
@@ -2,7 +2,6 @@
 import type { FastifyInstance, RouteOptions } from "fastify";
 import pc from "picocolors";
 import { loadModule, ModuleType } from ".";
-import type { ValidMethods } from "../modules/types";
 import { validMethods } from "../modules/types";
 
 export async function autoload(
@@ -17,7 +16,6 @@ export async function autoload(
     for (const [method, route] of Object.entries<RouteOptions>(module)) {
       if (validMethods.has(method)) {
         route.url = prefix ? `/${prefix}${url}` : url;
-        route.method = method.toUpperCase() as ValidMethods;
         route.prefixTrailingSlash = "both";
 
         fastify.route(route);


### PR DESCRIPTION
This pull request makes the `Route` and `AnyRoute` types generics so developers can customise the types of their bodies, headers, params, querystrings, and replies, rather than have them be set to `unknown`. This attempts to mirror Fastify's Typescript generics system, a quick guide can be found [here](https://www.fastify.io/docs/latest/Reference/TypeScript/).

I have also tidied up the types and removed some unused or uneeded types, and made the existing types more efficient.

This PR addresses #13 